### PR TITLE
Make username and password optional.

### DIFF
--- a/src/builder.js
+++ b/src/builder.js
@@ -13,7 +13,7 @@ export class Builder {
   constructor(options = defaultOptions, models = []) {
     let sequelizeArguments = [];
     if (options.databaseUrl) sequelizeArguments.push(options.databaseUrl);
-    if (!options.databaseUrl && options.database && options.username && options.pass) {
+    if (!options.databaseUrl && options.database) {
       sequelizeArguments = [options.database, options.username, options.pass];
     }
     sequelizeArguments.push(options.config);


### PR DESCRIPTION
_Sorry about the double request; I originally erroneously submitted this change as a pull request from my `master` branch. Obviously that creates issues when I commit anything else to `master`. Resubmitting pull request from a dedicated local branch._

Username and password should be optional fields. In particular, PostgreSQL authenticates as the current user if no username is specified.

This pull request makes Builder use the supplied database even if username and pass aren't specified. Without it, Builder will connect to the current user's default database if username and pass aren't specified on PostgreSQL.