### PR TITLE
Doco fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Sequelize Six
+# Sequelize Classes
 ![travis-ci](https://travis-ci.org/ConciergeAuctions/sequelize-classes.svg?branch=master) [![Stories in Ready](https://badge.waffle.io/ConciergeAuctions/sequelize-classes.svg?label=ready&title=Ready)](http://waffle.io/ConciergeAuctions/sequelize-classes)
 
 ## Overview

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Sequelize Six
-![travis-ci](https://travis-ci.org/ConciergeAuctions/sequelize-six.svg?branch=master) [![Stories in Ready](https://badge.waffle.io/ConciergeAuctions/sequelize-six.svg?label=ready&title=Ready)](http://waffle.io/ConciergeAuctions/sequelize-six)
+![travis-ci](https://travis-ci.org/ConciergeAuctions/sequelize-classes.svg?branch=master) [![Stories in Ready](https://badge.waffle.io/ConciergeAuctions/sequelize-classes.svg?label=ready&title=Ready)](http://waffle.io/ConciergeAuctions/sequelize-classes)
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ## Overview
 
-This package serves to assist in the creation of sequelize models via ES7 class syntax. 
+This package serves to assist in the creation of sequelize models via ES7 class syntax.
 
 ## Requirements
 
@@ -21,25 +21,25 @@ import {STRING} from 'sequelize';
 @hasMany('Post', {as: 'posts', foreignKey: 'authorId'})
 export default class User extends Model {
     username = {type: STRING, allowNull: false, unique: true};
-    email: {type: STRING, allowNull: false, unique: true};
-    firstName: {type: STRING};
-    lastName: {type: STRING};
-    
+    email = {type: STRING, allowNull: false, unique: true};
+    firstName = {type: STRING};
+    lastName = {type: STRING};
+
     get name() {
         return `${this.firstName} ${this.lastName}`;
     }
 }
 ```
 
-Note that this class is just a class, not a sequelize model at this point. The purpose of the Model class is to set up 
-your classes in such a way so that the Builder tool can create your sequelize model definitions properly. 
+Note that this class is just a class, not a sequelize model at this point. The purpose of the Model class is to set up
+your classes in such a way so that the Builder tool can create your sequelize model definitions properly.
 
 ## Using Builder to create your sequelize connection and define models
 
 ```
  import {Builder} from 'sequelize-classes';
  import {User} from './models/user';
- 
+
  // Normal sequelize options.
  const options = {
    database: process.env.DB_NAME,
@@ -52,9 +52,9 @@ your classes in such a way so that the Builder tool can create your sequelize mo
      dialect: 'postgres'
    }
  };
- 
+
  // Pass sequelize connection options and an array of Classes extended from Model.
  const database = new Builder(options, [User]);
- 
+
  // You can now access your sequelize instance via database.base and access all your models by name - database.User
 ```


### PR DESCRIPTION
Sorry yet another PR... this one just fixes a few minor documentation issues:
* change Sequelize Six references to Sequelize Classes to avoid confusion
  - also fixes Travis CI and Waffle badge URLs (my main reason for the changes & PR)
* resolve several whitespace issues (there was a mix of `LF` and `CRLF` line endings)
* replace object literal syntax (invalid in `class` declaration) with ES7 property initializers in the example model class.